### PR TITLE
5 cascading object state changes

### DIFF
--- a/Limnova/src/Orbital/OrbitalPhysics.h
+++ b/Limnova/src/Orbital/OrbitalPhysics.h
@@ -1177,7 +1177,7 @@ namespace Limnova
             m_Objects[object].Parent = parent;
             ComputeStateValidity(object);
             TryComputeAttributes(object);
-            // TODO : update satellites ?
+            TreeCascadeAttributeChanges(object);
         }
 
         TUserId GetParent(TObjectId object)
@@ -1217,9 +1217,7 @@ namespace Limnova
                 && radius > kMinLocalSpaceRadius - kEpsLocalSpaceRadius)
             {
                 m_LocalSpaces.Get(object).Radius = radius;
-
-                // TODO : update child positions
-
+                TreeCascadeAttributeChanges(object);
                 return true;
             }
             LV_CORE_ASSERT(!m_LocalSpaces[object].Influencing, "Local-space radius of influencing entities cannot be manually set (must be set equal to radius of influence)!");
@@ -1238,7 +1236,7 @@ namespace Limnova
             m_Objects[object].State.Mass = mass;
             ComputeStateValidity(object);
             TryComputeAttributes(object); /* NOTE: this should be redundant as orbital motion is independent of orbiter mass, but do it anyway just for consistency */
-            // TODO : update satellites ?
+            TreeCascadeAttributeChanges(object);
         }
 
         double GetMass(TObjectId object)
@@ -1258,7 +1256,7 @@ namespace Limnova
             m_Objects[object].State.Position = position;
             ComputeStateValidity(object);
             TryComputeAttributes(object);
-            // TODO : update satellites ?
+            TreeCascadeAttributeChanges(object);
         }
 
         Vector3 const& GetPosition(TObjectId object)
@@ -1277,7 +1275,7 @@ namespace Limnova
 
             m_Objects[object].State.Velocity = velocity;
             TryComputeAttributes(object);
-            // TODO : update satellites ?
+            TreeCascadeAttributeChanges(object);
         }
 
         Vector3d const& GetVelocity(TObjectId object)

--- a/Limnova/src/Orbital/OrbitalPhysics.h
+++ b/Limnova/src/Orbital/OrbitalPhysics.h
@@ -827,7 +827,7 @@ namespace Limnova
         }
 
 
-        void TreeTryComputeAttributes(TObjectId object)
+        void TreeCascadeAttributeChanges(TObjectId object)
         {
             std::vector<TObjectId> tree = {};
             GetObjectTree(tree, object);
@@ -1036,16 +1036,7 @@ namespace Limnova
         void SetRootScaling(double meters)
         {
             m_LocalSpaces[m_RootObject].MetersPerRadius = meters;
-
-            std::vector<TObjectId> tree = {};
-            GetObjectTree(tree, m_RootObject);
-            for (auto obj : tree) {
-                // TODO : preserve orbit shape ?
-                if (ComputeStateValidity(obj)) {
-                    TryComputeAttributes(obj);
-                }
-            }
-            TreeTryComputeAttributes(m_RootObject);
+            TreeCascadeAttributeChanges(m_RootObject);
         }
 
         double GetRootScaling()

--- a/Limnova/src/Orbital/OrbitalPhysics.h
+++ b/Limnova/src/Orbital/OrbitalPhysics.h
@@ -396,8 +396,9 @@ namespace Limnova
 
         bool ValidParent(TObjectId object)
         {
+            if (object == m_RootObject) return true;
             if (m_LocalSpaces[m_RootObject].MetersPerRadius > 0.0) {
-                return m_LocalSpaces.Has(m_Objects[object].Parent) || m_Objects[object].Parent == m_RootObject || object == m_RootObject;
+                return m_Objects[m_Objects[object].Parent].Validity == Validity::Valid;
             }
             LV_WARN("OrbitalPhysics root scaling has not been set!");
             return false;
@@ -824,6 +825,19 @@ namespace Limnova
                 }
             } while (numAdded > 0);
         }
+
+
+        void TreeTryComputeAttributes(TObjectId object)
+        {
+            std::vector<TObjectId> tree = {};
+            GetObjectTree(tree, object);
+            for (auto obj : tree) {
+                // TODO : preserve orbit shape ?
+                if (ComputeStateValidity(obj)) {
+                    TryComputeAttributes(obj);
+                }
+            }
+        }
     public:
         /*** Usage ***/
 
@@ -1027,8 +1041,11 @@ namespace Limnova
             GetObjectTree(tree, m_RootObject);
             for (auto obj : tree) {
                 // TODO : preserve orbit shape ?
-                TryComputeAttributes(obj);
+                if (ComputeStateValidity(obj)) {
+                    TryComputeAttributes(obj);
+                }
             }
+            TreeTryComputeAttributes(m_RootObject);
         }
 
         double GetRootScaling()

--- a/Limnova/src/Scene/Scene.cpp
+++ b/Limnova/src/Scene/Scene.cpp
@@ -194,11 +194,11 @@ namespace Limnova
             size_t end = entities.size();
             size_t idx = end - numAdded;
             numAdded = 0;
-            for (; idx < end; idx++)
-            {
+            while (idx < end) {
                 auto children = GetChildren(entities[idx]);
                 entities.insert(entities.end(), children.begin(), children.end());
                 numAdded += children.size();
+                idx++;
             }
         } while (numAdded > 0);
         return entities;

--- a/LimnovaEditor/Assets/Scenes/ExampleOrbital.limn
+++ b/LimnovaEditor/Assets/Scenes/ExampleOrbital.limn
@@ -62,10 +62,10 @@ Entities:
       ShowMajorMinorAxes: false
       ShowNormal: false
       Dynamic: false
-      Mass: 100000
+      Mass: 130000
       Position: [0.899999976, 0, 0]
       Velocity: [0, 0, -0.027232130077066794]
-      LocalSpaceRadius: 0.00899999961
+      LocalSpaceRadius: 0.0099958526
   - Entity: 16493328850430951057
     TagComponent:
       Tag: Player Ship
@@ -114,5 +114,5 @@ Entities:
       Dynamic: true
       Mass: 9.9999999999999998e-13
       Position: [-0.372700006, 0, 0]
-      Velocity: [0, -0, 0.085000000894069672]
+      Velocity: [0, 0, 0.095000000894069667]
       LocalSpaceRadius: 0.0199999996


### PR DESCRIPTION
Bugfix implemented - all satellite states are recomputed after changes to primary state.
Does not preserve absolute states or orbit shapes - see [dedicated issue](https://github.com/Limnovoid/Limnova/issues/6).