### PR TITLE
3 dynamic integration method selection

### DIFF
--- a/Limnova/src/Orbital/OrbitalPhysics.h
+++ b/Limnova/src/Orbital/OrbitalPhysics.h
@@ -45,6 +45,10 @@ namespace Limnova
         static constexpr Vector3 kReferenceNormal   = { 0.f, 1.f, 0.f };
 
         static constexpr double kGravitational = 6.6743e-11;
+
+
+        // Simulation tuning parameters ////////
+        // TODO : choose numbers based on reasoning/testing
         static constexpr float kDefaultLocalSpaceRadius = 0.1f;
         static constexpr float kLocalSpaceEscapeRadius = 1.01f;
 
@@ -54,12 +58,12 @@ namespace Limnova
         static constexpr float kMinLocalSpaceRadius = 0.01f;
         static constexpr float kEpsLocalSpaceRadius = 1e-6f;
 
-        static constexpr float kMaxObjectUpdates = 20.f; /* TODO : choose number based on reasoning/testing */
+        static constexpr float kMaxObjectUpdates = 20.f;
         static constexpr double kDefaultMinDT = 1.0 / (60.0 * kMaxObjectUpdates);
         static constexpr float kMinUpdateDistance = 1e-5f;
         static constexpr double kMinUpdateDistanced = (double)kMinUpdateDistance;
         static constexpr float kMinUpdateTrueAnomaly = 1e-5f;
-
+        ////////////////////////////////////////
     private:
         using TAttrId = uint32_t;
 

--- a/Limnova/src/Orbital/OrbitalScene.cpp
+++ b/Limnova/src/Orbital/OrbitalScene.cpp
@@ -417,7 +417,8 @@ namespace Limnova
 
 
             // debug
-            /*if (orbital.IsDynamic())
+#ifdef EXCLUDE
+            if (orbital.IsDynamic())
             {
                 auto& dynamics = orbital.GetDynamics();
                 if (dynamics.EscapeTrueAnomaly > 0.f)
@@ -427,10 +428,11 @@ namespace Limnova
                     Renderer2D::DrawCircle(primaryPosition + dynamics.EscapePoint, 0.01f, escapePointColor, 1.f, 0.f, (int)secondary);
                     Renderer2D::DrawCircle(primaryPosition + dynamics.EntryPoint, 0.01f, entryPointColor, 1.f, 0.f, (int)secondary);
                 }
-            }*/
+            }
             if (m_Physics.IsIntegrationLinear(orbital.PhysicsObjectId)) {
                 Renderer2D::DrawDashedLine(transform.GetPosition(), primaryPosition, { 1.f, 0.3f, 0.2f, m_OrbitAlpha }, m_OrbitThickness, 2.f, 2.f, editorPickingId);
             }
+#endif
         }
 
         // TODO : draw tertiaries as point lights orbiting secondaries

--- a/Limnova/src/Orbital/OrbitalScene.cpp
+++ b/Limnova/src/Orbital/OrbitalScene.cpp
@@ -428,6 +428,9 @@ namespace Limnova
                     Renderer2D::DrawCircle(primaryPosition + dynamics.EntryPoint, 0.01f, entryPointColor, 1.f, 0.f, (int)secondary);
                 }
             }*/
+            if (m_Physics.IsIntegrationLinear(orbital.PhysicsObjectId)) {
+                Renderer2D::DrawDashedLine(transform.GetPosition(), primaryPosition, { 1.f, 0.3f, 0.2f, m_OrbitAlpha }, m_OrbitThickness, 2.f, 2.f, editorPickingId);
+            }
         }
 
         // TODO : draw tertiaries as point lights orbiting secondaries

--- a/LimnovaEditor/EditorLayer.cpp
+++ b/LimnovaEditor/EditorLayer.cpp
@@ -517,7 +517,7 @@ namespace Limnova
 
         { // Object orbit durations
             m_ResizeInit(m_DurationErrors, objStats.size(), 0.f);
-            m_DurationErrorsOffsets.resize(objStats.size(), kObjPlotSpan); /* initialize offsets to max so that we can increment before assignment of new value */
+            m_DurationErrorsOffsets.resize(objStats.size(), kObjPlotSpan - 1); /* initialize offsets to max so that we can increment before assignment of new value */
 
             bool expanded = ImGui::TreeNode("Orbit duration errors");
             for (size_t object = 1; object < objStats.size(); object++)


### PR DESCRIPTION
Integration method changes dynamically in OnUpdate(): favouring angular integration, will switch to linear integration when the delta true anomaly which would occur for the optimal object delta time is below a minimum threshold, and will switch back to angular when this is no longer the case.