### PR TITLE
22 redesign orbits as sections

### DIFF
--- a/Limnova/src/Orbital/OrbitalPhysics.h
+++ b/Limnova/src/Orbital/OrbitalPhysics.h
@@ -1025,7 +1025,6 @@ namespace Limnova
             m_Ctx->m_Tree.Move(objNode.Id(), newLspNode.Id());
 
             objNode.Orbit().LocalSpace = newLspNode; // TEMPORARY ! TODO - use orbit sections to facilitate promotion/demotion
-            LV_CORE_ASSERT(false, "TODO - use orbit sections to facilitate promotion/demotion !");
 
             RescaleLocalSpaces(objNode, rescalingFactor);
             ComputeStateValidity(objNode);
@@ -1050,7 +1049,6 @@ namespace Limnova
             m_Ctx->m_Tree.Move(objNode.Id(), newLspNode.Id());
 
             objNode.Orbit().LocalSpace = newLspNode; // TEMPORARY ! TODO - use orbit sections to facilitate promotion/demotion
-            LV_CORE_ASSERT(false, "TODO - use orbit sections to facilitate promotion/demotion !");
 
             RescaleLocalSpaces(objNode, rescalingFactor);
             ComputeStateValidity(objNode);
@@ -1077,7 +1075,6 @@ namespace Limnova
             m_Ctx->m_Tree.Move(objNode.Id(), newLspNode.Id());
 
             objNode.Orbit().LocalSpace = newLspNode; // TEMPORARY ! TODO - use orbit sections to facilitate promotion/demotion
-            LV_CORE_ASSERT(false, "TODO - use orbit sections to facilitate promotion/demotion !");
 
             RescaleLocalSpaces(objNode, rescalingFactor);
             ComputeStateValidity(objNode);

--- a/Limnova/src/Orbital/OrbitalScene.cpp
+++ b/Limnova/src/Orbital/OrbitalScene.cpp
@@ -569,6 +569,10 @@ namespace Limnova
             }
         }*/
 
+        if (ohc.LocalSpaceRelativeToParent == -1) {
+            ohc.LocalSpaceRelativeToParent = 0;
+        }
+
         OrbitalPhysics::LSpaceNode localSpace;
         Entity entityParent = GetEntity(hc.Parent);
         if (!entityParent.HasComponent<OrbitalComponent>() || entityParent.GetComponent<OrbitalComponent>().LocalSpaces.size() == 0)
@@ -581,9 +585,6 @@ namespace Limnova
         }
         else
         {
-            if (ohc.LocalSpaceRelativeToParent == -1) {
-                ohc.LocalSpaceRelativeToParent = 0;
-            }
             auto& parentOc = entityParent.GetComponent<OrbitalComponent>();
             LV_CORE_ASSERT(parentOc.LocalSpaces.size() > ohc.LocalSpaceRelativeToParent, "Invalid relative local space index!");
             localSpace = parentOc.LocalSpaces[ohc.LocalSpaceRelativeToParent];

--- a/Limnova/src/Orbital/OrbitalScene.cpp
+++ b/Limnova/src/Orbital/OrbitalScene.cpp
@@ -138,7 +138,7 @@ namespace Limnova
             dstOc.ShowNormal = srcOc.ShowNormal;
 
             LV_CORE_ASSERT((dstOc.Object.GetObj().State.Position - srcOc.Object.GetObj().State.Position).SqrMagnitude() < 1e-5f, "Failed to adequately replicate position!");
-            LV_CORE_ASSERT(dstOc.Object.GetElements().E - srcOc.Object.GetElements().E < 1e-5f, "Failed to adequately replicate orbit shape!");
+            LV_CORE_ASSERT(dstOc.Object.GetOrbit().Elements.E - srcOc.Object.GetOrbit().Elements.E < 1e-5f, "Failed to adequately replicate orbit shape!");
             LV_CORE_ASSERT(dstOc.Object.GetDynamics().EscapeTrueAnomaly - srcOc.Object.GetDynamics().EscapeTrueAnomaly < 1e-5f, "Failed to adequately replicate dynamics!");
         }
         return newEntity;
@@ -447,7 +447,7 @@ namespace Limnova
             int editorPickingId = (int)(entity);
             auto [tc, oc] = GetComponents<TransformComponent, OrbitalComponent>(entity);
             auto& object = oc.Object.GetObj();
-            auto& elems = oc.Object.GetElements();
+            auto& elems = oc.Object.GetOrbit().Elements;
 
             if (object.Validity != OrbitalPhysics::Validity::Valid) continue;
 

--- a/Limnova/src/Orbital/OrbitalScene.h
+++ b/Limnova/src/Orbital/OrbitalScene.h
@@ -56,7 +56,8 @@ namespace Limnova
         void OnOrbitalComponentUpdate(entt::registry&, entt::entity);
         void OnOrbitalComponentDestruct(entt::registry&, entt::entity);
 
-        void OnLocalSpaceChange(OrbitalPhysics::ObjectNode objNode);
+        void OnParentLocalSpaceChange(OrbitalPhysics::ObjectNode objNode);
+        void OnChildLocalSpacesChange(OrbitalPhysics::ObjectNode objNode);
     public:
         Vector4 m_InfluencingSpaceColor = { 1.f, 0.9f, 0.3f, 0.3f };
         Vector4 m_LocalSpaceColor = { 1.f, 1.f, 1.f, 0.3f };

--- a/Limnova/src/Renderer/Renderer2D.cpp
+++ b/Limnova/src/Renderer/Renderer2D.cpp
@@ -849,7 +849,8 @@ namespace Limnova
 
     void Renderer2D::DrawOrbitalEllipse(const Vector3& center, const Quaternion& orientation, const OrbitalComponent& component, const Vector4& color, float thickness, float fade, int entityId)
     {
-        auto& elems = component.Object.GetOrbit().Elements;
+        auto& orbit = component.Object.GetOrbit();
+        auto& elems = orbit.Elements;
 
         Matrix4 transform = glm::translate(glm::mat4(1.f), (glm::vec3)center);
         transform = transform * Matrix4(orientation);
@@ -859,14 +860,14 @@ namespace Limnova
         Vector2 cutoffNormal = { 0.f }; /* the normal to the the cutoff line, equal to the unit direction vector of the orbit velocity at the cutoff point */
         if (component.Object.IsDynamic())
         {
-            auto& dynamics = component.Object.GetDynamics();
-            if (dynamics.EscapeTrueAnomaly > 0.f)
+            if (orbit.TaExit < PI2f) // TEMP ! will 
             {
-                cutoffPoint = dynamics.EscapePointPerifocal;
+                cutoffPoint = { OrbitalPhysics::kLocalSpaceEscapeRadius * cosf(orbit.TaExit) - elems.C, /* subtract center's x-offset to convert x-component to the perifocal frame */
+                    OrbitalPhysics::kLocalSpaceEscapeRadius * sinf(orbit.TaExit) };
 
                 // Compute cutoff normal from the orbit velocity at the cutoff point
-                cutoffNormal.x = -sinf(dynamics.EscapeTrueAnomaly);
-                cutoffNormal.y = elems.E + cosf(dynamics.EscapeTrueAnomaly);
+                cutoffNormal.x = -sinf(orbit.TaExit);
+                cutoffNormal.y = elems.E + cosf(orbit.TaExit);
                 cutoffNormal.Normalize();
             }
         }
@@ -936,16 +937,18 @@ namespace Limnova
 
     void Renderer2D::DrawOrbitalHyperbola(const Vector3& center, const Quaternion& orientation, const OrbitalComponent& component, const Vector4& color, float thickness, float fade, int entityId)
     {
-        auto& elems = component.Object.GetOrbit().Elements;
+        auto& orbit = component.Object.GetOrbit();
+        auto& elems = orbit.Elements;
         LV_CORE_ASSERT(elems.Type == OrbitalPhysics::OrbitType::Hyperbola, "Orbit must be hyperbolic!");
-        auto& dynamics = component.Object.GetDynamics();
 
-        Vector2 cutoffPoint = dynamics.EscapePointPerifocal; /* the point on the orbit path above the x-axis (positive y-component) at which the orbit should stop being drawn */
+        Vector2 cutoffPoint /* the point on the orbit path above the x-axis (positive y-component) at which the orbit should stop being drawn */
+            { OrbitalPhysics::kLocalSpaceEscapeRadius * cosf(orbit.TaExit) - elems.C, /* subtract center's x-offset to convert x-component to the perifocal frame */
+                OrbitalPhysics::kLocalSpaceEscapeRadius * sinf(orbit.TaExit)};
         Vector2 cutoffNormal = { 0.f }; /* the normal to the cutoff line, equal to the unit direction vector of the orbit velocity at the cutoff point */
 
         // Compute cutoff normal from the orbit velocity at the cutoff point
-        cutoffNormal.x = -sinf(dynamics.EscapeTrueAnomaly);
-        cutoffNormal.y = elems.E + cosf(dynamics.EscapeTrueAnomaly);
+        cutoffNormal.x = -sinf(orbit.TaExit);
+        cutoffNormal.y = elems.E + cosf(orbit.TaExit);
         cutoffNormal.Normalize();
 
         // Transform

--- a/Limnova/src/Renderer/Renderer2D.cpp
+++ b/Limnova/src/Renderer/Renderer2D.cpp
@@ -849,7 +849,7 @@ namespace Limnova
 
     void Renderer2D::DrawOrbitalEllipse(const Vector3& center, const Quaternion& orientation, const OrbitalComponent& component, const Vector4& color, float thickness, float fade, int entityId)
     {
-        auto& elems = component.Object.GetElements();
+        auto& elems = component.Object.GetOrbit().Elements;
 
         Matrix4 transform = glm::translate(glm::mat4(1.f), (glm::vec3)center);
         transform = transform * Matrix4(orientation);
@@ -936,7 +936,7 @@ namespace Limnova
 
     void Renderer2D::DrawOrbitalHyperbola(const Vector3& center, const Quaternion& orientation, const OrbitalComponent& component, const Vector4& color, float thickness, float fade, int entityId)
     {
-        auto& elems = component.Object.GetElements();
+        auto& elems = component.Object.GetOrbit().Elements;
         LV_CORE_ASSERT(elems.Type == OrbitalPhysics::OrbitType::Hyperbola, "Orbit must be hyperbolic!");
         auto& dynamics = component.Object.GetDynamics();
 

--- a/Limnova/src/Scene/SceneSerializer.cpp
+++ b/Limnova/src/Scene/SceneSerializer.cpp
@@ -513,7 +513,7 @@ namespace Limnova
             for (size_t i = 0; i < localSpaceRadiiNode.size(); i++) {
                 oc.Object.AddLocalSpace(localSpaceRadiiNode[i].as<float>());
             }
-            if (isRootEntity) { oc.LocalSpaces.clear(); }
+            oc.LocalSpaces.clear();
             oc.Object.GetLocalSpaces(oc.LocalSpaces);
 
             oc.UIColor      = oNode["UIColor"].as<Vector3>();

--- a/Limnova/src/Scene/SceneSerializer.cpp
+++ b/Limnova/src/Scene/SceneSerializer.cpp
@@ -405,7 +405,7 @@ namespace Limnova
             parentId = hcNode["Parent"].as<uint64_t>();
         }
 
-        bool isRootEntity = name == "Root";
+        bool isRootEntity = parentId == UUID::Null;
 
         Entity entity;
         if (isRootEntity) {

--- a/LimnovaEditor/Assets/Scenes/debugLsp.limn
+++ b/LimnovaEditor/Assets/Scenes/debugLsp.limn
@@ -15,7 +15,7 @@ ReferenceAxisArrowSize: 0.0240000002
 PerifocalAxisThickness: 0.00100000005
 PerifocalAxisArrowSize: 0.00499999989
 TrackingEntity: 14459431121056359079
-ViewSpace: 1
+ViewSpace: 2
 RootScaling: 1
 Entities:
   - Entity: 3991604775407627372
@@ -41,9 +41,6 @@ Entities:
       ShowMajorMinorAxes: false
       ShowNormal: false
       Mass: 1
-      Dynamic: false
-      Position: [0, 0, 0]
-      Velocity: [0, 0, 0]
       LocalSpaceRadii:
         []
   - Entity: 14459431121056359079
@@ -55,7 +52,7 @@ Entities:
       Position: [0, 0, 0]
       Orientation: [0, 0, 0, 1]
       EulerAngles: [0, 0, 0]
-      Scale: [0.0796214342, 0.0796214342, 0.0796214342]
+      Scale: [0.142857134, 0.142857134, 0.142857134]
     BillboardCircleRendererComponent:
       Color: [0, 0.729857922, 1, 1]
       Thickness: 1
@@ -84,7 +81,7 @@ Entities:
       Position: [0.810000002, 0, 0]
       Orientation: [0, 0, 0, 1]
       EulerAngles: [0, 0, 0]
-      Scale: [0.00796214305, 0.00796214305, 0.00796214305]
+      Scale: [0, 0, 0]
     BillboardCircleRendererComponent:
       Color: [1, 0, 1, 1]
       Thickness: 1
@@ -112,7 +109,7 @@ Entities:
       Position: [0.99000001, 0, 0]
       Orientation: [0, 0, 0, 1]
       EulerAngles: [0, 0, 0]
-      Scale: [0, 0, 0]
+      Scale: [0.00714285672, 0.00714285672, 0.00714285672]
     BillboardCircleRendererComponent:
       Color: [0, 1, 0.047393322, 1]
       Thickness: 1
@@ -128,7 +125,7 @@ Entities:
       Mass: 9.9999999999999998e-17
       Dynamic: true
       Position: [0.99000001, 0, 0]
-      Velocity: [0, 0, -0.00050000000000000001]
+      Velocity: [0, 0, -0.00014999999999999999]
       LocalSpaceRadii:
         []
   - Entity: 518833432052485731

--- a/LimnovaEditor/Assets/Scenes/debugLsp.limn
+++ b/LimnovaEditor/Assets/Scenes/debugLsp.limn
@@ -14,8 +14,8 @@ ReferenceAxisThickness: 0.00600000005
 ReferenceAxisArrowSize: 0.0240000002
 PerifocalAxisThickness: 0.00100000005
 PerifocalAxisArrowSize: 0.00499999989
-TrackingEntity: 518833432052485731
-ViewSpace: -1
+TrackingEntity: 14459431121056359079
+ViewSpace: 1
 RootScaling: 1
 Entities:
   - Entity: 3991604775407627372
@@ -41,18 +41,21 @@ Entities:
       ShowMajorMinorAxes: false
       ShowNormal: false
       Mass: 1
+      Dynamic: false
+      Position: [0, 0, 0]
+      Velocity: [0, 0, 0]
       LocalSpaceRadii:
         []
   - Entity: 14459431121056359079
     TagComponent:
-      Tag: Root child
+      Tag: Planet 0
     HierarchyComponent:
       Parent: 3991604775407627372
     TransformComponent:
       Position: [0, 0, 0]
       Orientation: [0, 0, 0, 1]
       EulerAngles: [0, 0, 0]
-      Scale: [0.052910056, 0.052910056, 0.052910056]
+      Scale: [0.0796214342, 0.0796214342, 0.0796214342]
     BillboardCircleRendererComponent:
       Color: [0, 0.729857922, 1, 1]
       Thickness: 1
@@ -74,14 +77,14 @@ Entities:
         - 0.00700000022
   - Entity: 13827553148329750021
     TagComponent:
-      Tag: Root child child
+      Tag: Moon 0
     HierarchyComponent:
       Parent: 14459431121056359079
     TransformComponent:
-      Position: [0, 0, 0]
+      Position: [0.810000002, 0, 0]
       Orientation: [0, 0, 0, 1]
       EulerAngles: [0, 0, 0]
-      Scale: [0, 0, 0]
+      Scale: [0.00796214305, 0.00796214305, 0.00796214305]
     BillboardCircleRendererComponent:
       Color: [1, 0, 1, 1]
       Thickness: 1
@@ -97,7 +100,7 @@ Entities:
       Mass: 1e-08
       Dynamic: false
       Position: [0.810000002, 0, 0]
-      Velocity: [5.0000000000000004e-06, -1.0000000000000001e-05, 6.4490000000000001e-05]
+      Velocity: [0, 0, -6.4491922823312195e-05]
       LocalSpaceRadii:
         []
   - Entity: 11506238116439127687
@@ -137,7 +140,7 @@ Entities:
       Position: [1, 0, 0]
       Orientation: [0, 0, 0, 1]
       EulerAngles: [0, 0, 0]
-      Scale: [0.0052910056, 0.0052910056, 0.0052910056]
+      Scale: [0, 0, 0]
     BillboardCircleRendererComponent:
       Color: [0.436018944, 0, 1, 1]
       Thickness: 1

--- a/LimnovaEditor/Panels/SceneHierarchyPanel.cpp
+++ b/LimnovaEditor/Panels/SceneHierarchyPanel.cpp
@@ -496,9 +496,9 @@ namespace Limnova
             // Absolute scale
             {
                 LimnGui::InputConfig<double> config;
+                config.Precision = 8;
                 if (LimnGui::InputVec3d("Absolute Scale", orbitalhc.AbsoluteScale, config))
                 {
-                    config.Precision = 8;
                     double lspScaling = 1.0 / ((OrbitalScene*)m_Scene)->GetLocalSpace(entity).GetLSpace().MetersPerRadius;
                     entity.GetComponent<TransformComponent>().SetScale((Vector3)(orbitalhc.AbsoluteScale * lspScaling));
                 }

--- a/LimnovaEditor/Panels/SceneHierarchyPanel.cpp
+++ b/LimnovaEditor/Panels/SceneHierarchyPanel.cpp
@@ -557,6 +557,8 @@ namespace Limnova
                     ImGui::SameLine();
 
                     auto lspNode = orbital.LocalSpaces[l];
+                    auto& lsp = lspNode.GetLSpace();
+
                     bool isSoi = lspNode.IsSphereOfInfluence();
                     if (isSoi) { ImGui::Text("Sphere of Influence"); }
                     else if (lspNode.IsInfluencing()) { ImGui::Text("Influencing"); }
@@ -570,17 +572,28 @@ namespace Limnova
                     }
 
                     // Radius
-                    float localSpaceRadius = lspNode.GetLSpace().Radius;
-                    LimnGui::InputConfig<float> config;
-                    config.Speed = 0.0001f;
-                    config.Precision = 4;
-                    config.Min = OrbitalPhysics::kMinLSpaceRadius;
-                    config.Max = OrbitalPhysics::kMaxLSpaceRadius;
-                    config.ReadOnly = isSoi; /* cannot resize spheres of influence ! */
-                    config.WidgetId = lspNode.Id();
-                    if (LimnGui::DragFloat("Radius", localSpaceRadius, config, 100.f)) {
-                        lspNode.SetRadius(localSpaceRadius);
-                        lspacesChanged = true;
+                    {
+                        float localSpaceRadius = lsp.Radius;
+                        LimnGui::InputConfig<float> config;
+                        config.Speed = 0.0001f;
+                        config.Precision = 4;
+                        config.Min = OrbitalPhysics::kMinLSpaceRadius;
+                        config.Max = OrbitalPhysics::kMaxLSpaceRadius;
+                        config.ReadOnly = isSoi; /* cannot resize spheres of influence ! */
+                        config.WidgetId = lspNode.Id();
+                        if (LimnGui::DragFloat("Radius", localSpaceRadius, config, 100.f)) {
+                            lspNode.SetRadius(localSpaceRadius);
+                            lspacesChanged = true;
+                        }
+                    }
+
+                    // Local gravity parameter
+                    {
+                        double grav = lsp.Grav;
+                        LimnGui::InputConfig<double> config;
+                        config.ReadOnly = true;
+                        config.WidgetId = lspNode.Id();
+                        LimnGui::InputDouble("Gravity Parameter", grav, config, 100.f);
                     }
 
                     // Context menu
@@ -689,17 +702,10 @@ namespace Limnova
             if (entity != m_Scene->GetRoot() &&
                 ImGui::TreeNode("Elements"))
             {
-                const auto& elems = orbital.Object.GetElements();
+                const auto& orbit = orbital.Object.GetOrbit();
+                const auto& elems = orbit.Elements;
                 if (ImGui::BeginTable("Elements", 2))
                 {
-                    ImGui::TableNextRow();
-
-                    ImGui::TableSetColumnIndex(0);
-                    ImGui::Text("Grav");
-                    LimnGui::HelpMarker("Gravity parameter");
-                    ImGui::TableSetColumnIndex(1);
-                    ImGui::Text("%.3e", elems.Grav);
-
                     ImGui::TableNextRow();
 
                     ImGui::TableSetColumnIndex(0);
@@ -729,7 +735,7 @@ namespace Limnova
                     ImGui::TableSetColumnIndex(0);
                     ImGui::Text("True anomaly");
                     ImGui::TableSetColumnIndex(1);
-                    ImGui::Text("%.3f", elems.TrueAnomaly);
+                    ImGui::Text("%.3f", orbit.TrueAnomaly);
 
                     ImGui::TableNextRow();
 
@@ -979,7 +985,6 @@ namespace Limnova
         return valueChanged;
     }
 
-
     bool LimnGui::InputInt(const std::string& label, int& value, const InputConfig<int>& config)
     {
         std::ostringstream idOss;
@@ -1000,7 +1005,6 @@ namespace Limnova
         return valueChanged;
     }
 
-
     bool LimnGui::InputScientific(const std::string& label, double& value, float columnWidth)
     {
         ImGui::PushID(label.c_str());
@@ -1014,6 +1018,29 @@ namespace Limnova
         double step = FromScientific<double, double, int>(1.0, e - 4);
         double stepFast = FromScientific<double, double, int>(1.0, e - 1);
         bool valueChanged = ImGui::InputDouble("##V", &value, step, stepFast, "%.4e", ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_CharsScientific);
+
+        ImGui::Columns(1);
+        ImGui::PopID();
+        return valueChanged;
+    }
+
+    bool LimnGui::InputDouble(const std::string& label, double& value, const InputConfig<double>& config, float columnWidth)
+    {
+        ImGuiInputTextFlags flags = ImGuiInputTextFlags_EnterReturnsTrue;
+        if (config.ReadOnly) flags |= ImGuiInputTextFlags_ReadOnly;
+
+        std::ostringstream idOss;
+        idOss << label << config.WidgetId;
+        ImGui::PushID(idOss.str().c_str());
+
+        ImGui::Columns(2);
+        ImGui::SetColumnWidth(0, columnWidth);
+        ImGui::Text(label.c_str());
+        ImGui::NextColumn();
+
+        std::ostringstream formatting;
+        formatting << "%." << config.Precision << "f";
+        bool valueChanged = ImGui::InputDouble("##V", &value, config.Speed, config.FastSpeed, formatting.str().c_str(), flags);
 
         ImGui::Columns(1);
         ImGui::PopID();
@@ -1042,7 +1069,6 @@ namespace Limnova
         ImGui::PopID();
         return valueChanged;
     }
-
 
     bool LimnGui::DragVec3(const std::string& label, Vector3& values, const InputConfig<float>& config, float columnWidth)
     {
@@ -1131,7 +1157,6 @@ namespace Limnova
         ImGui::PopID();
         return valueChanged;
     }
-
 
     bool LimnGui::InputVec3d(const std::string& label, Vector3d& values, const InputConfig<double>& config, float columnWidth)
     {

--- a/LimnovaEditor/Panels/SceneHierarchyPanel.h
+++ b/LimnovaEditor/Panels/SceneHierarchyPanel.h
@@ -48,6 +48,7 @@ namespace Limnova
         bool Checkbox(const std::string& label, bool& value, float columnWidth = 100.f);
         bool InputInt(const std::string& label, int& value, const InputConfig<int>& config = {});
         bool InputScientific(const std::string& label, double& value, float columnWidth = 100.f);
+        bool InputDouble(const std::string& label, double& value, const InputConfig<double>& config, float columnWidth = 100.f);
         bool DragFloat(const std::string& label, float& value, const InputConfig<float>& config, float columnWidth = 100.f);
         bool DragVec3(const std::string& label, Vector3& values, const InputConfig<float>& config, float columnWidth = 100.f);
         bool InputVec3d(const std::string& label, Vector3d& values, const InputConfig<double>& config, float columnWidth = 100.f);


### PR DESCRIPTION
Orbit data moved into orbit section objects which completely describe the orbital motion of an object in a given local space. A section contains its orbital elements, the range of motion in the local space (as start and end true anomalies), and the ID of its local space. This change is to better reflect the relationship between elements and local spaces in the library design, and to facilitate the intended future ability to describe an orbital path across multiple local spaces using multiple sections in a linked list.